### PR TITLE
Lazy Attribute indexing jobs

### DIFF
--- a/lib/esse/async_indexing.rb
+++ b/lib/esse/async_indexing.rb
@@ -50,6 +50,13 @@ module Esse::AsyncIndexing
 
     repo.respond_to?(:implement_batch_ids?) && repo.implement_batch_ids?
   end
+
+  def self.plugin_installed?(index)
+    index = index.index if index.is_a?(Class) && index < Esse::Repository
+    return false unless index.is_a?(Class) && index < Esse::Index
+
+    index.plugins.include?(Esse::Plugins::AsyncIndexing)
+  end
 end
 
 Esse::Config.__send__ :include, Esse::AsyncIndexing::Config

--- a/lib/esse/async_indexing/cli.rb
+++ b/lib/esse/async_indexing/cli.rb
@@ -29,4 +29,18 @@ Esse::CLI::Index.class_eval do
     require "esse/async_indexing/cli/async_import"
     Esse::AsyncIndexing::CLI::AsyncImport.new(indices: index_classes, **opts).run
   end
+
+  desc "async_update_lazy_attributes INDEX_CLASS", "Async update lazy attributes for the given index"
+  option :repo, type: :string, default: nil, alias: "-r", desc: "Repository to use for import"
+  option :suffix, type: :string, default: nil, aliases: "-s", desc: "Suffix to append to index name"
+  option :context, type: :hash, default: {}, required: true, desc: "List of options to pass to the index class"
+  option :service, type: :string, default: nil, alias: "-s", desc: "Service to use for async import: sidekiq, faktory"
+  option :job_options, type: :hash, default: {}, desc: "List of options to pass to the background job. (Example: --job-options=queue:default)"
+  def async_update_lazy_attributes(index_class, *attributes)
+    opts = Esse::HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+    opts[:service] ||= Esse.config.async_indexing.services.first
+    require "esse/async_indexing/cli/async_update_lazy_attributes"
+
+    Esse::AsyncIndexing::CLI::AsyncUpdateLazyAttributes.new(indices: [index_class], attributes: attributes, **opts).run
+  end
 end

--- a/spec/esse/async_indexing/cli/async_import_spec.rb
+++ b/spec/esse/async_indexing/cli/async_import_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Esse::CLI::Index", type: :cli do
       it "raises an error if the repository does not have the async_indexing plugin" do
         expect {
           cli_exec(%w[index async_import CountiesIndex])
-        }.to raise_error(Esse::CLI::InvalidOption, /The CountiesIndex::County repository does not support async indexing/)
+        }.to raise_error(Esse::CLI::InvalidOption, /The CountiesIndex index does not support async indexing. Make sure you have/)
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe "Esse::CLI::Index", type: :cli do
       it "allows --update-lazy-attributes as a single value" do
         Esse.config.async_indexing.faktory
         cli_exec(%w[index async_import CitiesIndex --update-lazy-attributes=foo])
-        expect{ "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("CitiesIndex", "city", [1, 2, 3], "update_lazy_attributes" => ["foo"]).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("CitiesIndex", "city", [1, 2, 3], "update_lazy_attributes" => ["foo"]).on(:faktory)
       end
 
       it "allows --update-lazy-attributes as multiple comma separated values" do
@@ -195,14 +195,14 @@ RSpec.describe "Esse::CLI::Index", type: :cli do
 
       it "enqueues the faktory job for the given index when passing --service=faktory" do
         cli_exec(%w[index async_import GeosIndex --service=faktory])
-        expect{ "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "country", [1, 2, 3], {}).on(:faktory)
-        expect{ "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "city", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "country", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "city", [1, 2, 3], {}).on(:faktory)
       end
 
       it "enqueues the faktory job for the given index when passing --service=sidekiq" do
         cli_exec(%w[index async_import GeosIndex --service=sidekiq])
-        expect{ "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "country", [1, 2, 3], {}).on(:sidekiq)
-        expect{ "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "city", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "country", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::ImportIdsJob" }.to have_enqueued_background_job("GeosIndex", "city", [1, 2, 3], {}).on(:sidekiq)
       end
     end
 

--- a/spec/esse/async_indexing/cli/async_update_lazy_attributes_spec.rb
+++ b/spec/esse/async_indexing/cli/async_update_lazy_attributes_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/cli_helpers"
+require "esse/cli"
+require "esse/async_indexing/cli/async_update_lazy_attributes"
+
+# rubocop:disable RSpec/ExpectActual
+# rubocop:disable RSpec/AnyInstance
+RSpec.describe "Esse::CLI::Index", type: :cli do
+  describe "#async_update_lazy_attributes" do
+    let(:index_collection_class) do
+      Class.new(Esse::Collection) do
+        def each_batch_ids
+          yield([1, 2, 3])
+        end
+      end
+    end
+
+    before do
+      Esse.config.async_indexing.faktory
+      Esse.config.async_indexing.sidekiq
+    end
+
+    after do
+      reset_config!
+    end
+
+    context "when passing undefined or invalid index name" do
+      it "raises an error if given argument is not a valid index class" do
+        expect {
+          cli_exec(%w[index async_update_lazy_attributes Esse::Config])
+        }.to raise_error(Esse::CLI::InvalidOption, /Esse::Config must be a subclass of Esse::Index/)
+      end
+
+      it "raises an error if given argument is not defined" do
+        expect {
+          cli_exec(%w[index async_update_lazy_attributes NotDefinedIndexName])
+        }.to raise_error(Esse::CLI::InvalidOption, /Unrecognized index class: "NotDefinedIndexName"/)
+      end
+    end
+
+    context "when passing an index that does not support async indexing" do
+      before do
+        collection_class = index_collection_class
+        stub_esse_index(:counties) do
+          repository :county do
+            collection collection_class
+          end
+        end
+      end
+
+      it "raises an error if the repository does not have the async_indexing plugin" do
+        expect {
+          cli_exec(%w[index async_update_lazy_attributes CountiesIndex])
+        }.to raise_error(Esse::CLI::InvalidOption, /The CountiesIndex index does not support async indexing. Make sure you have/)
+      end
+    end
+
+    context "when passing a index with single repository that supports async indexing" do
+      before do
+        collection_class = index_collection_class
+        stub_esse_index(:cities) do
+          plugin :async_indexing
+          repository :city do
+            collection collection_class
+            lazy_document_attribute :total_events do |docs|
+              docs.map { |doc| [doc.id, 10] }.to_h
+            end
+            lazy_document_attribute :total_venues do |docs|
+              docs.map { |doc| [doc.id, 20] }.to_h
+            end
+          end
+        end
+      end
+
+      it "enqueues the faktory job for the given index when passing --service=faktory" do
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job.on(:sidekiq)
+      end
+
+      it "detects faktory as the default service name when not passed and is set in the configuration" do
+        Esse.config.async_indexing.faktory
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job.on(:sidekiq)
+      end
+
+      it "enqueues the faktory job for the given index when passing --service=sidekiq" do
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex --service=sidekiq])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job.on(:faktory)
+      end
+
+      it "detects sidekiq as the default service name when not passed and is set in the configuration" do
+        Esse.config.async_indexing.sidekiq
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job.on(:faktory)
+      end
+
+      it "enqueues only the specified lazy attribute job when the attribute is passed" do
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex total_events --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:faktory)
+      end
+
+      it "removes invalid given attributes" do
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex total_venues invalid_attribute --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job("CitiesIndex", "city", "invalid_attribute", [1, 2, 3], {}).on(:faktory)
+      end
+
+      it "does not enqueue when no valid lazy attributes are passed" do
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex invalid_attribute --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job.on(:faktory)
+      end
+
+      it "allows --job-options with a Hash" do
+        Esse.config.async_indexing.faktory
+        cli_exec(%w[index async_update_lazy_attributes CitiesIndex --job-options=queue:bar])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_events", [1, 2, 3], {}).on(:faktory).queue("bar")
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("CitiesIndex", "city", "total_venues", [1, 2, 3], {}).on(:faktory).queue("bar")
+      end
+    end
+
+    context "when passing a index with multiple repositories that support async indexing" do
+      before do
+        collection_class = index_collection_class
+        stub_esse_index(:geos) do
+          plugin :async_indexing
+          repository :country do
+            collection collection_class
+            lazy_document_attribute :total_events do |docs|
+              docs.map { |doc| [doc.id, 10] }.to_h
+            end
+          end
+          repository :city do
+            collection collection_class
+            lazy_document_attribute :total_events do |docs|
+              docs.map { |doc| [doc.id, 10] }.to_h
+            end
+          end
+        end
+      end
+
+      it "enqueues the faktory job for the given index when passing --service=faktory" do
+        cli_exec(%w[index async_update_lazy_attributes GeosIndex --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("GeosIndex", "country", "total_events", [1, 2, 3], {}).on(:faktory)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("GeosIndex", "city", "total_events", [1, 2, 3], {}).on(:faktory)
+      end
+
+      it "enqueues the faktory job for the given index when passing --service=sidekiq" do
+        cli_exec(%w[index async_update_lazy_attributes GeosIndex --service=sidekiq])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("GeosIndex", "country", "total_events", [1, 2, 3], {}).on(:sidekiq)
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.to have_enqueued_background_job("GeosIndex", "city", "total_events", [1, 2, 3], {}).on(:sidekiq)
+      end
+    end
+
+    context "when passing a index with a custom indexing job defined" do
+      before do
+        collection_class = index_collection_class
+        stub_esse_index(:geos) do
+          plugin :async_indexing
+          repository :country do
+            collection collection_class
+            lazy_document_attribute :total_events do |docs|
+              docs.map { |doc| [doc.id, 10] }.to_h
+            end
+            async_indexing_job(:update_lazy_attribute) do |**options|
+              Thread.current[:custom_job] = options
+            end
+          end
+        end
+      end
+
+      it "enqueues the custom job for the given index when passing --service=faktory" do
+        cli_exec(%w[index async_update_lazy_attributes GeosIndex --service=faktory])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job
+        expect(Thread.current[:custom_job]).to eq(
+          service: :faktory,
+          repo: GeosIndex::Country,
+          operation: :update_lazy_attribute,
+          attribute: :total_events,
+          ids: [1, 2, 3]
+        )
+      end
+
+      it "enqueues the custom job for the given index when passing --service=sidekiq" do
+        cli_exec(%w[index async_update_lazy_attributes GeosIndex --service=sidekiq])
+        expect { "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob" }.not_to have_enqueued_background_job
+        expect(Thread.current[:custom_job]).to eq(
+          service: :sidekiq,
+          repo: GeosIndex::Country,
+          operation: :update_lazy_attribute,
+          attribute: :total_events,
+          ids: [1, 2, 3]
+        )
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/ExpectActual
+# rubocop:enable RSpec/AnyInstance

--- a/spec/esse/async_indexing/jobs/import_ids_job_spec.rb
+++ b/spec/esse/async_indexing/jobs/import_ids_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Esse::AsyncIndexing::Jobs::ImportIdsJob do
     context "when the worker has lazy_document_attributes" do
       before do
         stub_esse_index(:geos) do
+          plugin :async_indexing
           repository :city do
             collection { |**, &block| block.call([{id: 1, name: "City 1"}]) }
             document { |hash, **| {_id: hash[:id], name: hash[:name]} }

--- a/spec/esse/async_indexing_spec.rb
+++ b/spec/esse/async_indexing_spec.rb
@@ -88,4 +88,30 @@ RSpec.describe Esse::AsyncIndexing do
       expect { described_class.service_name(:invalid) }.to raise_error(ArgumentError, "Invalid service: :invalid, valid services are: sidekiq, faktory")
     end
   end
+
+  describe ".plugin_installed?" do
+    it "returns false when the given index is not a Esse::Index" do
+      expect(described_class.plugin_installed?(nil)).to be(false)
+      expect(described_class.plugin_installed?(Object)).to be(false)
+      expect(described_class.plugin_installed?(Esse::Repository)).to be(false)
+      expect(described_class.plugin_installed?(Esse::Index)).to be(false)
+    end
+
+    it "returns false when the given index does not have the :async_indexing plugin" do
+      stub_esse_index(:geos) do
+        repository :state, const: true
+      end
+      expect(described_class.plugin_installed?(GeosIndex)).to be(false)
+      expect(described_class.plugin_installed?(GeosIndex::State)).to be(false)
+    end
+
+    it "returns true when the given index have the :async_indexing plugin" do
+      stub_esse_index(:geos) do
+        plugin :async_indexing
+        repository :state, const: true
+      end
+      expect(described_class.plugin_installed?(GeosIndex)).to be(true)
+      expect(described_class.plugin_installed?(GeosIndex::State)).to be(true)
+    end
+  end
 end

--- a/spec/esse/plugin/async_indexing/async_indexing_job_spec.rb
+++ b/spec/esse/plugin/async_indexing/async_indexing_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Esse::Plugins::AsyncIndexing, "#async_indexing_job" do # rubocop:
         async_indexing_job { |service, repo, op, ids, **kwargs| }
       end
     end
-    expect(GeosIndex::State.async_indexing_jobs.keys).to match_array(%i[import index update delete])
+    expect(GeosIndex::State.async_indexing_jobs.keys).to match_array(%i[import index update delete update_lazy_attribute])
     expect(GeosIndex::State.async_indexing_jobs).to be_frozen
   end
 


### PR DESCRIPTION
Add new CLI command `async_update_lazy_attributes` to enqueue jobs related lazy document attributes