### PR TITLE
Global Task definition

### DIFF
--- a/lib/esse/async_indexing.rb
+++ b/lib/esse/async_indexing.rb
@@ -20,6 +20,7 @@ end
 require_relative "async_indexing/version"
 require_relative "async_indexing/actions"
 require_relative "async_indexing/config"
+require_relative "async_indexing/tasks"
 require_relative "async_indexing/errors"
 require_relative "async_indexing/jobs"
 require_relative "plugins/async_indexing"

--- a/lib/esse/async_indexing/active_record_callbacks/lazy_update_attribute.rb
+++ b/lib/esse/async_indexing/active_record_callbacks/lazy_update_attribute.rb
@@ -14,6 +14,7 @@ module Esse::AsyncIndexing
 
       def call(model)
         if (doc_ids = resolve_document_ids(model))
+          # @TODO Fixme
           BackgroundJob.job(service_name, LAZY_ATTR_WORKER)
             .with_args(repo.index.name, repo.repo_name, attribute_name.to_s, doc_ids, options)
             .push

--- a/lib/esse/async_indexing/cli/async_import.rb
+++ b/lib/esse/async_indexing/cli/async_import.rb
@@ -35,9 +35,9 @@ class Esse::AsyncIndexing::CLI::AsyncImport < Esse::CLI::Index::BaseOperation
           MSG
         end
 
-        enqueuer = if (caller = repo.async_indexing_jobs[:import])
+        enqueuer = if repo.async_indexing_job?(:import)
           ->(ids) do
-            caller.call(service: service_name, repo: repo, operation: :import, ids: ids, **bulk_options)
+            repo.async_indexing_job_for(:import).call(service: service_name, repo: repo, operation: :import, ids: ids, **bulk_options)
           end
         else
           ->(ids) do

--- a/lib/esse/async_indexing/cli/async_update_lazy_attributes.rb
+++ b/lib/esse/async_indexing/cli/async_update_lazy_attributes.rb
@@ -39,10 +39,10 @@ class Esse::AsyncIndexing::CLI::AsyncUpdateLazyAttributes < Esse::CLI::Index::Ba
         attrs = repo_attributes(repo)
         next unless attrs.any?
 
-        enqueuer = if (caller = repo.async_indexing_jobs[:update_lazy_attribute])
+        enqueuer = if repo.async_indexing_job?(:update_lazy_attribute)
           ->(ids) do
             attrs.each do |attribute|
-              caller.call(service: service_name, repo: repo, operation: :update_lazy_attribute, attribute: attribute, ids: ids, **bulk_options)
+              repo.async_indexing_job_for(:update_lazy_attribute).call(service: service_name, repo: repo, operation: :update_lazy_attribute, attribute: attribute, ids: ids, **bulk_options)
             end
           end
         else

--- a/lib/esse/async_indexing/configuration.rb
+++ b/lib/esse/async_indexing/configuration.rb
@@ -19,6 +19,7 @@ module Esse
 
       def reset!
         @services = nil
+        @tasks = nil
         bg_job_config.reset!
       end
 
@@ -48,6 +49,22 @@ module Esse
           conf
         else raise ArgumentError, "Unknown service: #{service}"
         end
+      end
+
+      def tasks
+        @tasks ||= Esse::AsyncIndexing::Tasks.new
+      end
+
+      # DSL to define custom job enqueueing
+      #
+      # task(:import) do |service:, repo:, operation:, ids:, **kwargs|
+      #   MyCustomJob.perform_later(repo.index.name, ids, **kwargs)
+      # end
+      # task(:index, :update, :delete) do |service:, repo:, operation:, id, **kwargs|
+      #   MyCustomJob.perform_later(repo.index.name, [id], **kwargs)
+      # end
+      def task(*operations, &block)
+        tasks.define(*operations, &block)
       end
 
       private

--- a/lib/esse/async_indexing/tasks.rb
+++ b/lib/esse/async_indexing/tasks.rb
@@ -41,6 +41,42 @@ module Esse
         }
       }.freeze
 
+      def initialize
+        @tasks = {}.freeze
+      end
+
+      def user_defined?(name)
+        @tasks.key?(name.to_sym)
+      end
+
+      def define(*names, &block)
+        names = DEFAULT.keys if names.empty?
+        validate!(names, block)
+        new_tasks = names.each_with_object({}) { |name, h| h[name.to_sym] = block }
+        @tasks = @tasks.dup.merge(new_tasks)
+      ensure
+        @tasks.freeze
+      end
+
+      def fetch(name)
+        id = name.to_sym
+        @tasks[id] || DEFAULT[id] || raise(ArgumentError, "Unknown task: #{name}")
+      end
+      alias_method :[], :fetch
+
+      private
+
+      def validate!(names, block)
+        unless block.is_a?(Proc)
+          raise ArgumentError, "The block of task must be a callable object"
+        end
+
+        names.each do |name|
+          unless DEFAULT.key?(name)
+            raise ArgumentError, "Unrecognized task: #{name}. Valid tasks are: #{DEFAULT.keys}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/esse/async_indexing/tasks.rb
+++ b/lib/esse/async_indexing/tasks.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Esse
+  module AsyncIndexing
+    class Tasks
+      DEFAULT = {
+        import: ->(service:, repo:, operation:, ids:, **kwargs) {
+          unless (ids = Esse::ArrayUtils.wrap(ids)).empty?
+            BackgroundJob.job(service, "Esse::AsyncIndexing::Jobs::ImportIdsJob")
+              .with_args(repo.index.name, repo.repo_name, ids, Esse::HashUtils.deep_transform_keys(kwargs, &:to_s))
+              .push
+          end
+        },
+        index: ->(service:, repo:, operation:, id:, **kwargs) {
+          if id
+            BackgroundJob.job(service, "Esse::AsyncIndexing::Jobs::DocumentIndexByIdJob")
+              .with_args(repo.index.name, repo.repo_name, id, Esse::HashUtils.deep_transform_keys(kwargs, &:to_s))
+              .push
+          end
+        },
+        update: ->(service:, repo:, operation:, id:, **kwargs) {
+          if id
+            BackgroundJob.job(service, "Esse::AsyncIndexing::Jobs::DocumentUpdateByIdJob")
+              .with_args(repo.index.name, repo.repo_name, id, Esse::HashUtils.deep_transform_keys(kwargs, &:to_s))
+              .push
+          end
+        },
+        delete: ->(service:, repo:, operation:, id:, **kwargs) {
+          if id
+            BackgroundJob.job(service, "Esse::AsyncIndexing::Jobs::DocumentDeleteByIdJob")
+              .with_args(repo.index.name, repo.repo_name, id, Esse::HashUtils.deep_transform_keys(kwargs, &:to_s))
+              .push
+          end
+        },
+        update_lazy_attribute: ->(service:, repo:, operation:, attribute:, ids:, **kwargs) {
+          unless (ids = Esse::ArrayUtils.wrap(ids)).empty?
+            BackgroundJob.job(service, "Esse::AsyncIndexing::Jobs::BulkUpdateLazyAttributeJob")
+              .with_args(repo.index.name, repo.repo_name, attribute.to_s, ids, Esse::HashUtils.deep_transform_keys(kwargs, &:to_s))
+              .push
+          end
+        }
+      }.freeze
+
+    end
+  end
+end

--- a/spec/esse/async_indexing/active_record_callbacks/lazy_update_attribute_spec.rb
+++ b/spec/esse/async_indexing/active_record_callbacks/lazy_update_attribute_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Esse::AsyncIndexing::ActiveRecordCallbacks::LazyUpdateAttribute d
   before do
     setup_esse_client!
     stub_esse_index(:geos) do
+      plugin :async_indexing
       repository :city do
         collection { |**, &block| block.call([{id: 1, name: "City 1"}]) }
         document { |hash, **| {_id: hash[:id], name: hash[:name]} }

--- a/spec/esse/async_indexing/configuration_spec.rb
+++ b/spec/esse/async_indexing/configuration_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Esse::AsyncIndexing::Configuration do
-  describe ".faktory" do
+  describe "#faktory" do
     it "returns the faktory config" do
       config = described_class.new
       expect(config.faktory).to be_a(BackgroundJob::Configuration::Faktory)
@@ -15,7 +15,7 @@ RSpec.describe Esse::AsyncIndexing::Configuration do
     end
   end
 
-  describe ".sidekiq" do
+  describe "#sidekiq" do
     it "returns the sidekiq config" do
       config = described_class.new
       expect(config.sidekiq).to be_a(BackgroundJob::Configuration::Sidekiq)
@@ -27,7 +27,7 @@ RSpec.describe Esse::AsyncIndexing::Configuration do
     end
   end
 
-  describe ".config_for" do
+  describe "#config_for" do
     it "returns the config for the given service" do
       config = described_class.new
       expect(config.config_for(:faktory)).to be_an_instance_of(BackgroundJob::Configuration::Faktory)
@@ -40,7 +40,22 @@ RSpec.describe Esse::AsyncIndexing::Configuration do
     end
   end
 
-  describe ".reset!" do
+  describe "#services" do
+    it "returns the services config" do
+      config = described_class.new
+      expect(config.services).to be_a(Esse::AsyncIndexing::ConfigService)
+    end
+  end
+
+  describe "#tasks" do
+    it "returns the tasks config" do
+      config = described_class.new
+      expect(config.tasks).to be_a(Esse::AsyncIndexing::Tasks)
+    end
+  end
+
+
+  describe "#reset!" do
     it "resets the config" do
       config = described_class.new
       config.faktory { |c| c.jobs["MyJob"] = {} }
@@ -48,6 +63,8 @@ RSpec.describe Esse::AsyncIndexing::Configuration do
       config.reset!
       expect(config.instance_variable_get(:@faktory)).to be_nil
       expect(config.instance_variable_get(:@sidekiq)).to be_nil
+      expect(config.instance_variable_get(:@services)).to be_nil
+      expect(config.instance_variable_get(:@tasks)).to be_nil
     end
   end
 end

--- a/spec/esse/async_indexing/tasks_spec.rb
+++ b/spec/esse/async_indexing/tasks_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Esse::AsyncIndexing::Tasks do
+  let(:tasks) { described_class.new }
+
+  describe "#user_defined?" do
+    shared_examples "a user defined task for" do |task_name|
+      it "returns false when the block is not given" do
+        expect(tasks.user_defined?(task_name)).to be(false)
+      end
+
+      it "returns true when the block is given" do
+        tasks.define(task_name) { |**| }
+        expect(tasks.user_defined?(task_name)).to be(true)
+      end
+    end
+
+    it_behaves_like "a user defined task for", :import
+    it_behaves_like "a user defined task for", :index
+    it_behaves_like "a user defined task for", :update
+    it_behaves_like "a user defined task for", :delete
+    it_behaves_like "a user defined task for", :update_lazy_attribute
+  end
+
+  describe "#define" do
+    it "raises an error when the task is invalid" do
+      expect { tasks.define(:unknown) {} }.to raise_error(ArgumentError, /Unrecognized task: unknown/)
+    end
+
+    shared_examples "a task definition for" do |task_name|
+      it "defines a task" do
+        task = ->(**) {}
+        tasks.define(task_name, &task)
+        expect(tasks[task_name]).to eq(task)
+      end
+
+      it "raises an error when block is not given" do
+        expect { tasks.define(task_name) }.to raise_error(ArgumentError, /The block of task must be a callable object/)
+      end
+
+      it "freezes the tasks" do
+        tasks.define(task_name) { |**| }
+        expect(tasks.instance_variable_get(:@tasks)).to be_frozen
+      end
+    end
+
+    it_behaves_like "a task definition for", :import
+    it_behaves_like "a task definition for", :index
+    it_behaves_like "a task definition for", :update
+    it_behaves_like "a task definition for", :delete
+    it_behaves_like "a task definition for", :update_lazy_attribute
+
+    context "when multiple tasks are defined" do
+      it "defines multiple tasks" do
+        import_task = ->(**) {}
+        tasks.define(:import, :index, &import_task)
+        expect(tasks[:import]).to eq(import_task)
+        expect(tasks[:index]).to eq(import_task)
+      end
+    end
+  end
+
+  describe "#fetch" do
+    it "raises an error when the task is unknown" do
+      expect { tasks.fetch(:unknown) }.to raise_error(ArgumentError, /Unknown task: unknown/)
+    end
+
+    shared_examples "a task fetch for" do |task_name|
+      it "returns the default task" do
+        expect(tasks.fetch(task_name)).to be_a(Proc)
+      end
+
+      it "returns the user-defined task" do
+        task = ->(**) {}
+        tasks.define(task_name, &task)
+        expect(tasks.fetch(task_name)).to be(task)
+      end
+    end
+
+    it_behaves_like "a task fetch for", :import
+    it_behaves_like "a task fetch for", :index
+    it_behaves_like "a task fetch for", :update
+    it_behaves_like "a task fetch for", :delete
+    it_behaves_like "a task fetch for", :update_lazy_attribute
+  end
+end

--- a/spec/esse/plugin/async_indexing/async_indexing_job_for_spec.rb
+++ b/spec/esse/plugin/async_indexing/async_indexing_job_for_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Esse::Plugins::AsyncIndexing, "#async_indexing_job_for" do # rubo
 
       expect {
         GeosIndex::State.async_indexing_job_for(:unknown)
-      }.to raise_error(ArgumentError, /unknown operation/)
+      }.to raise_error(ArgumentError, /Unknown task: unknown/)
     end
   end
 end


### PR DESCRIPTION
Extend the configuration to allow define tasks like `:index`, `:import`, `:update`, `:delete` and `update_lazy_attribute`. Now it's possible to define this caller in both global and repository level.