### PR TITLE
docs: add usage and API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This gem provides a way to [Esse](https://github.com/marcosgz/esse) index documents asynchronously using [Faktory](https://github.com/contribsys/faktory_worker_ruby) or [Sidekiq](https://github.com/sidekiq/sidekiq).
 
+## Documentation
+
+Full guides, job configuration, and API reference are published at **[gems.marcosz.com.br/esse-async_indexing](https://gems.marcosz.com.br/esse-async_indexing/)** — part of the [marcosgz Ruby gem catalogue](https://gems.marcosz.com.br).
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,86 @@
+# esse-async_indexing
+
+Background indexing for [Esse](../../esse/docs/README.md). Offload index/update/delete and bulk import operations to **Sidekiq** or **Faktory** instead of running them inline.
+
+## What you get
+
+- Jobs for all standard operations: index, update, upsert, delete, import IDs, import all, bulk lazy-attribute update.
+- A plugin (`plugin :async_indexing`) that adds `batch_ids` and `async_indexing_job` DSL to repositories.
+- CLI commands: `esse index async_import`, `esse index async_update_lazy_attributes`.
+- ActiveRecord integration: `async_index_callback`, `async_update_lazy_attribute_callback`.
+- Per-operation configuration of queue, retries, and custom job classes.
+
+## Contents
+
+- [Usage guide](usage.md)
+- [API reference](api.md)
+
+## Quick start
+
+```ruby
+# Gemfile
+gem 'esse', '>= 0.4.0.rc1'
+gem 'esse-async_indexing'
+gem 'sidekiq' # or 'faktory_worker_ruby'
+```
+
+```ruby
+# config/initializers/esse.rb
+require 'esse/async_indexing'
+
+Esse.configure do |config|
+  config.async_indexing.sidekiq do |sidekiq|
+    sidekiq.redis = ConnectionPool.new(size: 10) { Redis.new(url: ENV['REDIS_URL']) }
+  end
+end
+```
+
+```ruby
+# app/indices/geos_index.rb
+class GeosIndex < Esse::Index
+  plugin :async_indexing
+
+  repository :city do
+    collection Collections::CityCollection
+    document Documents::CityDocument
+  end
+end
+
+class Collections::CityCollection < Esse::Collection
+  def each(&block)
+    ::City.find_in_batches { |rows| block.call(rows, @params) }
+  end
+
+  # REQUIRED for async indexing — yields ID batches for ImportIdsJob
+  def each_batch_ids
+    ::City.select(:id).find_in_batches { |rows| yield(rows.map(&:id)) }
+  end
+end
+```
+
+Run an async import:
+
+```bash
+bundle exec esse index async_import GeosIndex --repo city --service sidekiq
+```
+
+With ActiveRecord callbacks:
+
+```ruby
+require 'esse/async_indexing/active_record'
+
+class City < ApplicationRecord
+  include Esse::AsyncIndexing::ActiveRecord::Model
+  async_index_callback('geos_index:city', service_name: :sidekiq) { id }
+end
+```
+
+## Version
+
+- Version: **0.1.0.rc4**
+- Ruby: `>= 2.7.0`
+- Depends on: `esse >= 0.4.0.rc1`, `background_job`, `multi_json`
+
+## License
+
+MIT.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,199 @@
+# API Reference
+
+## `Esse::AsyncIndexing`
+
+### Module methods
+
+#### `worker(worker_class, service:, **options)`
+
+Build a `BackgroundJob` instance for the given worker class and service. Used internally by actions and callbacks.
+
+#### `service_name(identifier = nil)`
+
+Normalize and validate a service identifier (`:sidekiq`, `:faktory`).
+
+#### `async_indexing_repo?(repo)`
+
+Returns `true` if the repo responds to `implement_batch_ids?` and its collection implements `each_batch_ids`.
+
+#### `plugin_installed?(index)`
+
+Returns `true` when `plugin :async_indexing` has been declared on the index.
+
+---
+
+## `Esse::Plugins::AsyncIndexing`
+
+Plugin module. Enable with:
+
+```ruby
+class GeosIndex < Esse::Index
+  plugin :async_indexing
+end
+```
+
+### Repository class methods
+
+#### `batch_ids(*args, **kwargs)`
+
+Yields ID batches from the collection. Delegates to `collection.each_batch_ids`. Used by jobs and CLI commands.
+
+#### `implement_batch_ids?`
+
+Returns `true` when the collection implements `each_batch_ids`.
+
+#### `async_indexing_job(*operations, &block)`
+
+Declare a custom job handler for one or more operations.
+
+```ruby
+async_indexing_job(:import) do |service:, repo:, operation:, ids:, **kwargs|
+  MyJob.perform_async(...)
+end
+```
+
+Operation keys: `:import`, `:index`, `:update`, `:delete`, `:update_lazy_attribute`.
+
+#### `async_indexing_job?(operation)` / `async_indexing_job_for(operation)`
+
+Check for a custom handler or retrieve it.
+
+---
+
+## `Esse::AsyncIndexing::Configuration`
+
+Accessed via `Esse.config.async_indexing`.
+
+### `sidekiq(&block)` / `faktory(&block)`
+
+Register a service. The block receives a `ConfigService` instance.
+
+```ruby
+config.async_indexing.sidekiq do |sidekiq|
+  sidekiq.redis = redis_pool
+end
+```
+
+### `config_for(service)`
+
+Get a previously configured service.
+
+### `services`
+
+Returns a set of configured services (`Set<Symbol>`).
+
+### `task(*operations, &block)`
+
+Register a global task handler. Overrides defaults for the named operations.
+
+---
+
+## `Esse::AsyncIndexing::ConfigService`
+
+Returned by `sidekiq` / `faktory`. Attributes vary per service:
+
+- **Sidekiq**: `redis` (ConnectionPool), `namespace` (String), `jobs` (Hash of per-job overrides).
+- **Faktory**: `jobs` (Hash of per-job overrides).
+
+Predicates: `sidekiq?`, `faktory?`.
+
+---
+
+## `Esse::AsyncIndexing::Jobs`
+
+All jobs live under this namespace. Their `.perform(...)` signatures:
+
+| Class | Signature |
+|-------|-----------|
+| `DocumentIndexByIdJob` | `(index, repo, id, options = {})` |
+| `DocumentUpdateByIdJob` | `(index, repo, id, options = {})` |
+| `DocumentUpsertByIdJob` | `(index, repo, id, operation = 'index', options = {})` |
+| `DocumentDeleteByIdJob` | `(index, repo, id, options = {})` |
+| `ImportIdsJob` | `(index, repo, ids, options = {})` |
+| `ImportAllJob` | `(index, repo, options = {})` |
+| `BulkUpdateLazyAttributeJob` | `(index, repo, attribute, ids, options = {})` |
+
+Each delegates to the matching `Esse::AsyncIndexing::Actions::*` class.
+
+### Module methods
+
+- `Jobs.install!(service, **options)` — require and wire up job classes for the given service.
+- `Jobs::DEFAULT` — hash of default job class paths.
+
+---
+
+## `Esse::AsyncIndexing::Actions`
+
+Callable wrappers that execute inline (no queue). Used inside jobs and available for direct calls.
+
+| Class | `.call` signature | Returns |
+|-------|--------------------|---------|
+| `IndexDocument` | `(index, repo, id, options = {})` | `:indexed` / `:not_found` |
+| `UpdateDocument` | `(index, repo, id, options = {})` | `:indexed` / `:not_found` |
+| `UpsertDocument` | `(index, repo, id, operation, options = {})` | `:indexed` |
+| `DeleteDocument` | `(index, repo, id, options = {})` | `:deleted` / `:not_found` |
+| `BulkImport` | `(index, repo, ids, options = {})` | import result |
+| `BulkImportAll` | `(index, repo, options = {})` | import result |
+| `BulkUpdateLazyAttribute` | `(index, repo, attribute, ids, options = {})` | `ids` |
+| `CoerceIndexRepository` | `(index, repo)` | `[index_class, repo_class]`. Raises `ArgumentError` on invalid input. |
+
+---
+
+## `Esse::AsyncIndexing::ActiveRecord::Model`
+
+Requires loading:
+
+```ruby
+require 'esse/async_indexing/active_record'
+
+class City < ApplicationRecord
+  include Esse::AsyncIndexing::ActiveRecord::Model
+end
+```
+
+### `async_index_callback(reference, on: [...], with: nil, **opts, &block)`
+
+Enqueue an index/update/delete job on commit.
+
+| Option | Description |
+|--------|-------------|
+| `reference` | `'index_name:repo_name'` or class-constant form |
+| `on:` | `[:create, :update, :destroy]` subset |
+| `with:` | `:update` for partial updates |
+| `service_name:` | `:sidekiq` or `:faktory` (required) |
+| `if:` / `unless:` | Standard AR conditionals |
+| `&block` | Returns document IDs to enqueue |
+
+### `async_update_lazy_attribute_callback(reference, attribute, on: [...], **opts, &block)`
+
+Enqueue `BulkUpdateLazyAttributeJob` on commit.
+
+Options are the same as `async_index_callback`, plus `attribute` (first positional).
+
+---
+
+## CLI extensions
+
+Added via `Esse::CLI::Index`:
+
+- `esse index async_import`
+- `esse index async_update_lazy_attributes`
+
+See the [usage guide](usage.md) for options.
+
+---
+
+## Errors
+
+| Error | Description |
+|-------|-------------|
+| `Esse::AsyncIndexing::Error` | Base |
+| `Esse::AsyncIndexing::NotDefinedWorkerError` | Raised when no worker is configured for a service |
+
+---
+
+## Integration notes
+
+- Built on top of the [`background_job`](https://github.com/marcosgz/background_job) gem, which abstracts Sidekiq and Faktory.
+- `esse-async_indexing` extends `Esse::Config` via module inclusion — the `async_indexing` reader is added automatically when you `require 'esse/async_indexing'`.
+- Callbacks register with the `Esse::ActiveRecord::Callbacks` registry (from [esse-active_record](../../esse-active_record/docs/README.md)), so `Esse::ActiveRecord::Hooks.without_indexing` also disables async callbacks.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,218 @@
+# Usage Guide
+
+## Installation
+
+```ruby
+# Gemfile
+gem 'esse'
+gem 'esse-async_indexing'
+gem 'sidekiq'  # or 'faktory_worker_ruby'
+```
+
+## Configuration
+
+The gem adds `config.async_indexing` to `Esse.configure`:
+
+```ruby
+# config/initializers/esse.rb
+require 'esse/async_indexing'
+
+Esse.configure do |config|
+  config.async_indexing.sidekiq do |sidekiq|
+    sidekiq.redis = ConnectionPool.new(size: 10, timeout: 5) do
+      Redis.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379'))
+    end
+    sidekiq.namespace = 'myapp' # optional
+  end
+
+  # Per-job queue / retry overrides
+  config.async_indexing.sidekiq.jobs = {
+    'Esse::AsyncIndexing::Jobs::DocumentIndexByIdJob' => { queue: 'indexing' },
+    'Esse::AsyncIndexing::Jobs::ImportIdsJob'         => { queue: 'batch_indexing', retry: 2 }
+  }
+end
+```
+
+Faktory equivalents:
+
+```ruby
+Esse.configure do |config|
+  config.async_indexing.faktory
+end
+```
+
+Both services can be configured side-by-side; pick per-callback with `service_name:`.
+
+## Enabling the plugin
+
+```ruby
+class GeosIndex < Esse::Index
+  plugin :async_indexing
+
+  repository :city do
+    collection Collections::CityCollection
+    document   Documents::CityDocument
+  end
+end
+```
+
+The plugin adds two capabilities to every repository:
+
+1. `batch_ids(*args, **kwargs)` — yields ID batches from the collection (requires `each_batch_ids`).
+2. `async_indexing_job(*ops, &block)` — override how jobs are enqueued per operation.
+
+## Collection requirements
+
+Your collection **must implement `each_batch_ids`** for async indexing to work:
+
+```ruby
+class CityCollection < Esse::Collection
+  def each(&block)
+    ::City.find_in_batches { |rows| block.call(rows, @params) }
+  end
+
+  def each_batch_ids
+    ::City.select(:id).find_in_batches { |rows| yield(rows.map(&:id)) }
+  end
+end
+```
+
+`esse-active_record` and `esse-sequel` collections already implement this.
+
+## Async callbacks
+
+```ruby
+require 'esse/async_indexing/active_record'
+
+class City < ApplicationRecord
+  include Esse::AsyncIndexing::ActiveRecord::Model
+
+  async_index_callback('geos_index:city', service_name: :sidekiq) { id }
+
+  async_update_lazy_attribute_callback(
+    'states_index:state', 'cities_count',
+    if: :state_id?,
+    service_name: :sidekiq
+  ) { state_id }
+end
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `service_name:` | `:sidekiq` or `:faktory` (required) |
+| `on:` | Which events (`:create`, `:update`, `:destroy`). Default: all |
+| `with:` | `:update` for partial updates |
+| `if:` / `unless:` | Standard AR conditionals |
+| `**other` | Forwarded to the job |
+
+The block returns the document ID(s) to enqueue.
+
+## Direct job enqueuing
+
+```ruby
+# Through the action classes
+Esse::AsyncIndexing::Actions::IndexDocument.call('GeosIndex', 'city', city.id)
+
+# Or directly via background_job
+BackgroundJob
+  .sidekiq('Esse::AsyncIndexing::Jobs::DocumentIndexByIdJob')
+  .with_args('GeosIndex', 'city', city.id)
+  .push
+```
+
+## CLI
+
+### `esse index async_import`
+
+```bash
+bundle exec esse index async_import GeosIndex \
+  --repo city \
+  --service sidekiq \
+  --suffix 20240401 \
+  --context state_abbr:IL \
+  --job-options queue:batch_indexing
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--repo` / `-r` | Repository name |
+| `--suffix` / `-s` | Target index suffix |
+| `--service` | `sidekiq` or `faktory` |
+| `--context` | Hash for scope filtering |
+| `--preload-lazy-attributes` | Preload via search |
+| `--eager-load-lazy-attributes` | Resolve during bulk |
+| `--update-lazy-attributes` | Refresh as partial updates |
+| `--enqueue-lazy-attributes` | `true`/`false` — auto-enqueue lazy updates after import |
+| `--job-options` | Hash of options applied to each enqueued job |
+
+The command walks `each_batch_ids` and pushes one `ImportIdsJob` per batch. The job then:
+
+1. Calls `Actions::BulkImport` for its batch.
+2. Optionally enqueues `BulkUpdateLazyAttributeJob` for each declared lazy attribute.
+
+### `esse index async_update_lazy_attributes`
+
+```bash
+bundle exec esse index async_update_lazy_attributes GeosIndex \
+  --repo city \
+  --service sidekiq \
+  cities_count total_schools
+```
+
+Enqueues one `BulkUpdateLazyAttributeJob` per attribute + batch.
+
+## Custom job handlers
+
+Override how a specific operation is enqueued:
+
+```ruby
+class GeosIndex < Esse::Index
+  plugin :async_indexing
+
+  repository :city do
+    async_indexing_job(:import) do |service:, repo:, operation:, ids:, **kwargs|
+      MyCustomImportJob.perform_async(repo.index.name, ids, kwargs)
+    end
+
+    async_indexing_job(:index, :update) do |service:, repo:, operation:, id:, **kwargs|
+      # ...
+    end
+  end
+end
+```
+
+Or globally in `Esse.configure`:
+
+```ruby
+Esse.configure do |config|
+  config.async_indexing.task(:import) do |service:, repo:, operation:, ids:, **kwargs|
+    CustomJob.perform_later(repo.index.name, ids, **kwargs)
+  end
+end
+```
+
+## Supported adapters
+
+| Adapter | Setup | Notes |
+|---------|-------|-------|
+| Sidekiq | `config.async_indexing.sidekiq { |s| s.redis = ... }` | Requires Redis |
+| Faktory | `config.async_indexing.faktory` | Uses Faktory server |
+
+Both are thin wrappers over the [`background_job`](https://github.com/marcosgz/background_job) gem.
+
+## Operating notes
+
+- **Retries**: Configure per-job via `config.async_indexing.sidekiq.jobs = { 'JobClass' => { retry: 2 } }`.
+- **Queues**: Same override mechanism, `queue: 'indexing'`.
+- **Error handling**: Jobs handle `Esse::Transport::NotFoundError` silently (treat as already-deleted).
+- **Ordering**: Async indexing is eventually consistent — do not rely on ordering between callbacks and reads within the same request.
+
+## Troubleshooting
+
+- **`NotDefinedWorkerError`**: The plugin couldn't find a job class for the service. Ensure `gem 'sidekiq'` or `gem 'faktory_worker_ruby'` is loaded.
+- **CLI says collection doesn't implement `each_batch_ids`**: Implement it in your custom `Esse::Collection`, or use `esse-active_record` / `esse-sequel` which provide it out of the box.
+- **Jobs run but nothing is indexed**: Check that the index has `plugin :async_indexing` and the collection `batch_ids` yields data. `GeosIndex.repo(:city).implement_batch_ids?` should be `true`.


### PR DESCRIPTION
## Summary

Adds `docs/` with three files:

- `README.md` — overview and entry point
- `usage.md` — how to configure background indexing via Sidekiq or Faktory
- `api.md` — reference for adapters, workers, and queue configuration

## Test plan

- [ ] Skim `docs/README.md` as a navigation entry point
- [ ] Verify Sidekiq/Faktory setup examples match the current API
- [ ] Verify worker class names and options in `api.md` are current